### PR TITLE
Fix deserialization of LootTableEntry

### DIFF
--- a/SubnauticaRandomiser/Objects/LootTable.cs
+++ b/SubnauticaRandomiser/Objects/LootTable.cs
@@ -131,8 +131,8 @@ namespace SubnauticaRandomiser.Objects
     [Serializable]
     public struct LootTableEntry<T>
     {
-        public readonly T Item;
-        public readonly double DropRate;
+        public T Item;
+        public double DropRate;
 
         public LootTableEntry(T item, double odds)
         {


### PR DESCRIPTION
Because the LootTableEntry fields are readonly, the deserializer seems not to be able to properly create entries. This causes the loot tables to only have a single `None` entry after loading a saved game. To reproduce the issue, simply start a game, save it, and then quit to menu. Load the save, then warp to a few wrecks and pick up fragments until you get a duplicate. You'll get a None item,

The details can be observed by adding a debug log to the Add function: `PrefixLogHandler.Get("[LT]").Debug($"add {item.Item}");` gives log entries like:
```
[Debug  :Subnautica Randomiser] [LT] add None
[Debug  :Subnautica Randomiser] [LT] add None
[Debug  :Subnautica Randomiser] [LT] add None
[Debug  :Subnautica Randomiser] [LT] add None
[Debug  :Subnautica Randomiser] [LT] add None
[Debug  :Subnautica Randomiser] [LT] add None
...
```

After the patch, it instead looks like:
```

[Debug  :Subnautica Randomiser] [LT] add CrashPowder
[Debug  :Subnautica Randomiser] [LT] add Copper
[Debug  :Subnautica Randomiser] [LT] add ScrapMetal
[Debug  :Subnautica Randomiser] [LT] add Quartz
[Debug  :Subnautica Randomiser] [LT] add Salt
[Debug  :Subnautica Randomiser] [LT] add Titanium
...
```

and the behavior works as expected. As to why this changed in 0.12.0, not sure, but I built and tested the fix, and verified that it worked.